### PR TITLE
fix/header-broken-link

### DIFF
--- a/examples/realtime/pitchmelodia/example.html
+++ b/examples/realtime/pitchmelodia/example.html
@@ -17,7 +17,7 @@
         <div class="ui main_wrapper landing-image">
 
         <div class="ui header centered" id="header">
-          <a href="/examples/">
+          <a href="/essentia.js/examples/">
             <img id="header-img" src="../../../src/assets/img/essentiajsbanner.png">
           </a>
           <div>


### PR DESCRIPTION
replaced the link from '/examples/' to '/essentia.js/examples/'