### PR TITLE
Fix Eigen library compilation error for custom extractors

### DIFF
--- a/src/cpp/custom/Makefile
+++ b/src/cpp/custom/Makefile
@@ -25,7 +25,8 @@ build:
 	@echo "Done ..."
 	   
 	# Sync builds for ES6 import and AudioWorklet support ...
-	@emcc --bind -Oz bindings_extractor.cpp essentia_custom_extractor.cpp ${LIB_DIR_ESSENTIA}/essentia.a \
+	@emcc -I $(EIGEN_PATH) \
+		--bind -Oz bindings_extractor.cpp essentia_custom_extractor.cpp ${LIB_DIR_ESSENTIA}/essentia.a \
 		-s WASM=1 \
 		-o $(ESSENTIA_JS_MODULE) \
 		-s BINARYEN_ASYNC_COMPILATION=0 \


### PR DESCRIPTION

When compiling a custom extractor the following error happend:

`In file included from custom_bindings_extractor.cpp:2:
In file included from ./custom_extractor.h:5:
In file included from /emsdk/upstream/emscripten/system/local/include/essentia/algorithmfactory.h:26:
/emsdk/upstream/emscripten/system/local/include/essentia/types.h:33:10: fatal error: 'unsupported/Eigen/CXX11/Tensor' file not found
#include <unsupported/Eigen/CXX11/Tensor>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
`