### PR TITLE
Fixes issue #78: replace broken code links and improve UX

### DIFF
--- a/examples/melspectrogram-rt/index.html
+++ b/examples/melspectrogram-rt/index.html
@@ -92,6 +92,7 @@
                     return Promise
                         .all(promises)
                         .then((texts) => {
+                            texts.unshift("var exports = {};"); // hack to make injected umd modules work
                             const text = texts.join('');
                             const blob = new Blob([text], {type: "application/javascript"});
 
@@ -327,9 +328,10 @@
                         gain = audioCtx.createGain();
                         gain.gain.setValueAtTime(0, audioCtx.currentTime);
 
-                        let codeForProcessorModule = ["https://cdn.jsdelivr.net/npm/essentia.js@0.1.0/dist/essentia-wasm.module.js", 
-                                                                                    "https://cdn.jsdelivr.net/npm/essentia.js@0.1.0/dist/essentia.js-extractor.es.js", 
-                                                                                    "melspectrogram-processor.js", "https://unpkg.com/ringbuf.js@0.1.0/dist/index.js"];
+                        let codeForProcessorModule = ["https://cdn.jsdelivr.net/npm/essentia.js@0.1.3/dist/essentia-wasm.umd.js",
+                        "https://cdn.jsdelivr.net/npm/essentia.js@0.1.3/dist/essentia.js-extractor.umd.js", 
+                        "melspectrogram-processor.js",
+                        "https://unpkg.com/ringbuf.js@0.1.0/dist/index.js"];
 
                         // inject Essentia.js code into AudioWorkletGlobalScope context, then setup audio graph and start animation
                         URLFromFiles(codeForProcessorModule)

--- a/examples/melspectrogram-rt/index.html
+++ b/examples/melspectrogram-rt/index.html
@@ -37,7 +37,7 @@
                 
             <div class="body-container">
                 <div class="ui centered one column grid container">
-                    <div class="ui vertical buttons row">
+                    <div class="ui vertical buttons row" id="recordButtonContainer">
                         <center>
                             <button id="recordButton" class="ui red inverted big button record-button" role="switch">
                                 Mic &nbsp;&nbsp;<i class="microphone icon"></i>
@@ -509,12 +509,20 @@
                         // add event listeners to ui objects
                         $("#recordButton").on('click', onRecordClickHandler);
                     } catch (e) {
-                        if (e instanceof ReferenceError) {
+                        if (e instanceof ReferenceError && !crossOriginIsolated) {
                             $("#recordButton").prop('disabled', true);
-                            if (confirm("This demo will NOT work in this browser: SharedArrayBuffer is not available or the necessary security headers are missing. We have hosted a version compatible with Firefox, and Chrome version 91 or later, at 'https://essentiajs-melspectrogram.netlify.app', would you like to check it out?")) {
-                                window.open('https://essentiajs-melspectrogram.netlify.app');
-                            }
+                            // redirect to cross-origin isolated SAB-capable version on Netlify
+                            window.location = "https://essentiajs-melspectrogram.netlify.app";
+                            return;
                         }
+
+                        // Unknown malfunction: alert user and offer alternative
+                        $("#recordButtonContainer").before(`
+                            <div class="ui message">
+                                <div class="header">Unable to run app</div>
+                                <p><a href="https://essentiajs-melspectrogram.netlify.app">Check out this version! <i class="external alternate icon"></i><a/></p>
+                                <p style="font-weight: 300;"><a href="https://github.com/MTG/essentia.js/issues">Let us know <i class="icon comment"></i></a></p>
+                            </div>`);
                     }
                 });
             })();

--- a/examples/melspectrogram-rt/index.html
+++ b/examples/melspectrogram-rt/index.html
@@ -17,7 +17,7 @@
 
         <div class="ui main_wrapper landing-image">
             <div class="ui header centered" id="header">
-                <a href="index.html">
+                <a href="https://mtg.github.io/essentia.js/" target="_blank">
                     <img
                         id="header-img"
                         src="./images/essentiajsbanner.png"
@@ -25,7 +25,7 @@
                 </a>
                 <div>
                     <h2 class="ui header white-text" style="color: azure;">
-                        LogMelSpectrogram extraction using Web Audio API (AudioWorklets)
+                        Real-time mel-spectrogram visualization
                     </h2>
                     <div class="ui basic large button">
                         <a href="https://github.com/MTG/essentia.js/tree/dev/examples/melspectrogram-rt/" target="_blank" class="ui small button">Code<i class="right github icon"></i></a>

--- a/examples/melspectrogram-rt/melspectrogram-processor.js
+++ b/examples/melspectrogram-rt/melspectrogram-processor.js
@@ -1,6 +1,5 @@
-// avoid ES Module imports: not available on workers in Firefox nor Safari 
-var exports = {};
-let essentiaExtractor = new EssentiaExtractor(Module);
+// avoid ES Module imports: not available on workers in Firefox nor Safari
+let essentiaExtractor = new EssentiaExtractor(exports.EssentiaWASM);
 
 function Float32Concat(first, second)
 {

--- a/examples/melspectrogram-rt/netlify.toml
+++ b/examples/melspectrogram-rt/netlify.toml
@@ -1,0 +1,5 @@
+[[headers]]
+    for = "/*"
+    [headers.values]
+        Cross-Origin-Opener-Policy = "same-origin"
+        Cross-Origin-Embedder-Policy = "require-corp"

--- a/examples/pitchmelodia-rt/index.html
+++ b/examples/pitchmelodia-rt/index.html
@@ -352,12 +352,20 @@
                         const testSAB = new SharedArrayBuffer(1);
                         delete testSAB;
                     } catch (e) {
-                        if (e instanceof ReferenceError) {
+                        if (e instanceof ReferenceError && !crossOriginIsolated) {
                             $("#recordButton").prop("disabled", true);
-                            if (confirm("This demo will NOT work in this browser: SharedArrayBuffer is not available or the necessary security headers are missing. We have hosted a version compatible with Firefox, and Chrome version 91 or later, at 'https://essentiajs-pitchmelodia.netlify.app', would you like to check it out?")) {
-                                window.open('https://essentiajs-pitchmelodia.netlify.app');
-                            }
+                            // redirect to cross-origin isolated SAB-capable version on Netlify
+                            window.location = "https://essentiajs-pitchmelodia.netlify.app";
+                            return;
                         }
+
+                        // Unknown malfunction: alert user and offer alternative
+                        $("#recordButtonContainer").before(`
+                            <div class="ui message">
+                                <div class="header">Unable to run app</div>
+                                <p><a href="https://essentiajs-melspectrogram.netlify.app">Check out this version! <i class="external alternate icon"></i><a/></p>
+                                <p style="font-weight: 300;"><a href="https://github.com/MTG/essentia.js/issues">Let us know <i class="icon comment"></i></a></p>
+                            </div>`);
                     }
                 });
             })();

--- a/examples/pitchmelodia-rt/index.html
+++ b/examples/pitchmelodia-rt/index.html
@@ -17,7 +17,7 @@
         
         <div class="ui main_wrapper landing-image">
             <div class="ui header centered" id="header">
-                <a href="index.html">
+                <a href="https://mtg.github.io/essentia.js/" target="_blank">
                     <img
                         id="header-img"
                         src="./images/essentiajsbanner.png"
@@ -25,7 +25,7 @@
                 </a>
                 <div>
                     <h2 class="ui header white-text" style="color: azure;">
-                        Real-time pitch extraction with Essentia.js
+                        Real-time pitch extraction
                     </h2>
                     <div class="ui basic large button">
                         <a href="https://github.com/MTG/essentia.js/tree/dev/examples/pitchmelodia-rt/" target="_blank" class="ui small button">Code<i class="right github icon"></i></a>

--- a/examples/pitchmelodia-rt/index.html
+++ b/examples/pitchmelodia-rt/index.html
@@ -93,6 +93,7 @@
                     return Promise
                         .all(promises)
                         .then((texts) => {
+                        texts.unshift("var exports = {};"); // hack to make injected umd modules work
                         const text = texts.join('');
                         const blob = new Blob([text], {type: "application/javascript"});
 
@@ -210,9 +211,10 @@
                         gain = audioCtx.createGain();
                         gain.gain.setValueAtTime(0, audioCtx.currentTime);
 
-                        let codeForProcessorModule = ["https://cdn.jsdelivr.net/npm/essentia.js@0.1.0/dist/essentia-wasm.module.js", 
-                                                                                    "https://cdn.jsdelivr.net/npm/essentia.js@0.1.0/dist/essentia.js-extractor.es.js", 
-                                                                                    "pitchyinprob-processor.js", "https://unpkg.com/ringbuf.js@0.1.0/dist/index.js"];
+                        let codeForProcessorModule = ["https://cdn.jsdelivr.net/npm/essentia.js@0.1.3/dist/essentia-wasm.umd.js", 
+                                                    "https://cdn.jsdelivr.net/npm/essentia.js@0.1.3/dist/essentia.js-core.umd.js", 
+                                                    "pitchyinprob-processor.js", 
+                                                    "https://unpkg.com/ringbuf.js@0.1.0/dist/index.js"];
 
                         // inject Essentia.js code into AudioWorkletGlobalScope context, then setup audio graph and start animation
                         URLFromFiles(codeForProcessorModule)

--- a/examples/pitchmelodia-rt/netlify.toml
+++ b/examples/pitchmelodia-rt/netlify.toml
@@ -1,0 +1,5 @@
+[[headers]]
+    for = "/*"
+    [headers.values]
+        Cross-Origin-Opener-Policy = "same-origin"
+        Cross-Origin-Embedder-Policy = "require-corp"

--- a/examples/pitchmelodia-rt/pitchyinprob-processor.js
+++ b/examples/pitchmelodia-rt/pitchyinprob-processor.js
@@ -1,5 +1,4 @@
 // avoid ES Module imports: not available on workers in Firefox nor Safari 
-var exports = {};
 let essentia = new Essentia(Module);
 
 function Float32Concat(first, second)


### PR DESCRIPTION
Demos affected:
- melspectrogram-rt
- pitchmelodia-rt

Changes:
- "Code" links now point to valid github page
- Using redirect to Netlify version when not cross-origin isolated (not served with appropriate HTTP headers), instead of using `window.confirm` and `window.open`, which tend to result in opaque blocked pop-up windows and poor user experience.
- Improved pages' titles and added link to Essentia.js homepage from banner .png