### PR TITLE
Extend node.js essentia examples and fix typos

### DIFF
--- a/examples/nodejs-basic-examples/README.md
+++ b/examples/nodejs-basic-examples/README.md
@@ -1,0 +1,12 @@
+# Node.js basic examples
+
+## Setup
+
+- Install node dependecies
+
+`npm install --save-dev`
+
+- Run example by
+
+`node <script>.js`
+

--- a/examples/nodejs-basic-examples/framewise-feature.js
+++ b/examples/nodejs-basic-examples/framewise-feature.js
@@ -28,7 +28,7 @@ let frames = essentia.FrameGenerator(
     1024 // hopSize
 );
 
-// Iterate through frames and compute ReplayGain feature
+// Iterate through frames and compute RMS value for each overlapping frame
 for (var i=0; i < frames.size(); i++) {
     // Compute RMS for each frame of downmixed audio signal
     let rms = essentia.RMS(

--- a/examples/nodejs-basic-examples/framewise-feature.js
+++ b/examples/nodejs-basic-examples/framewise-feature.js
@@ -1,0 +1,44 @@
+// A simple Node.js example of using essentia.js for feature extraction.
+// Install dependencies 
+// Run `node main.js`
+var fs = require('fs');
+let wav = require('node-wav');
+var esLib = require('essentia.js');
+
+const essentia = new esLib.Essentia(esLib.EssentiaWASM);
+console.log("essentia.js version: ", essentia.version);
+
+let buffer = fs.readFileSync('../../test/data/test.wav');
+// Decode wav audio file using node-wav package
+let audio = wav.decode(buffer);
+
+// Optional: downmix stereo audio to mono
+// We use MonoMixer algorithm from Essentia for that.
+// We need to convert audio data into 
+const audioLeftChannelData = essentia.arrayToVector(audio.channelData[0]);
+const audioRightChannelData = essentia.arrayToVector(audio.channelData[1]);
+const audioDownMixed = essentia.MonoMixer(audioLeftChannelData, audioRightChannelData).audio;
+
+// Convert back to float32 array for FrameGenerator;
+const audioData = essentia.vectorToArray(audioDownMixed);
+// Create overlapping frames of the audio with given frameSize and hopSize
+let frames = essentia.FrameGenerator(
+    audioData, // audio data as float32 typed array
+    2048, // frameSize
+    1024 // hopSize
+);
+
+// Iterate through frames and compute ReplayGain feature
+for (var i=0; i < frames.size(); i++) {
+    // Compute RMS for each frame of downmixed audio signal
+    let rms = essentia.RMS(
+        frames.get(i), // audio frame vector
+    ).rms;
+    console.log("RMS: ", rms);
+};
+
+// delete frames from memmory
+frames.delete();
+
+// After the use of essentia.js
+essentia.delete();

--- a/examples/nodejs-basic-examples/mono-audio-file.js
+++ b/examples/nodejs-basic-examples/mono-audio-file.js
@@ -1,0 +1,28 @@
+// A simple Node.js example of using essentia.js for feature extraction.
+// Install dependencies 
+// Run `node main.js`
+var fs = require('fs');
+let wav = require('node-wav');
+var esLib = require('essentia.js');
+
+const essentia = new esLib.Essentia(esLib.EssentiaWASM);
+console.log("essentia.js version: ", essentia.version);
+
+let buffer = fs.readFileSync('../../test/data/test.wav');
+// Decode wav audio file using node-wav package
+let audio = wav.decode(buffer);
+
+// Assuming your input audio file is in Mono
+const audioVector = essentia.arrayToVector(audio.channelData[0])
+
+let danceability = essentia.Danceability(
+    audioVector, // audio data
+    8800, // maxTau
+    310, // minTau
+    audio.sampleRate // sampleRate
+).danceability;
+
+console.log("Danceability: ", danceability);
+
+// After the use of essentia.js
+essentia.delete();

--- a/examples/nodejs-basic-examples/mono-audio-file.js
+++ b/examples/nodejs-basic-examples/mono-audio-file.js
@@ -15,6 +15,7 @@ let audio = wav.decode(buffer);
 // Assuming your input audio file is in Mono
 const audioVector = essentia.arrayToVector(audio.channelData[0])
 
+// Danceability expects the whole audio file as input
 let danceability = essentia.Danceability(
     audioVector, // audio data
     8800, // maxTau

--- a/examples/nodejs-basic-examples/package.json
+++ b/examples/nodejs-basic-examples/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "nodejs-basic-examples",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "essentia.js": "^0.1.3",
+    "fs": "^0.0.1-security",
+    "node-wav": "^0.0.2"
+  }
+}

--- a/examples/nodejs-basic-examples/stereo-audio-file.js
+++ b/examples/nodejs-basic-examples/stereo-audio-file.js
@@ -1,34 +1,33 @@
 // A simple Node.js example of using essentia.js for feature extraction.
+// Install dependencies 
 // Run `node main.js`
-
 var fs = require('fs');
+let wav = require('node-wav');
 var esLib = require('essentia.js');
+
 const essentia = new esLib.Essentia(esLib.EssentiaWASM);
 console.log("essentia.js version: ", essentia.version);
 
-let wav = require('node-wav');
 let buffer = fs.readFileSync('../../test/data/test.wav');
 // Decode wav audio file using node-wav package
 let audio = wav.decode(buffer);
-// Convert audio data into VectorFloat type
+
+// Optional: downmix stereo audio to mono
+// We use MonoMixer algorithm from Essentia for that.
+// We need to convert audio data into 
 const audioLeftChannelData = essentia.arrayToVector(audio.channelData[0]);
 const audioRightChannelData = essentia.arrayToVector(audio.channelData[1]);
-// Downmix stereo audio to mono
 const audioDownMixed = essentia.MonoMixer(audioLeftChannelData, audioRightChannelData).audio;
 
-// Create overlapping frames of the audio with given frameSize and hopSize
-let frames = essentia.FrameGenerator(audioDownMixed,
-    1024, // frameSize
-    512 // hopSize
-);
 
-// Iterate through frames and compute danceability feature
-for (var i=0; i < frames.size(); i++) {
-    let danceability = essentia.Danceability(frames.get(i)).danceability;
-    console.log("Danceability: ", danceability);
-};
-// delete frames from memmory
-frames.delete();
+let danceability = essentia.Danceability(
+    audioDownMixed, // audio frame vector
+    8800, // maxTau
+    310, // minTau
+    audio.sampleRate // sampleRate
+).danceability;
+
+console.log("Danceability: ", danceability);
 
 // After the use of essentia.js
 essentia.delete();

--- a/examples/nodejs-basic-examples/stereo-audio-file.js
+++ b/examples/nodejs-basic-examples/stereo-audio-file.js
@@ -19,7 +19,7 @@ const audioLeftChannelData = essentia.arrayToVector(audio.channelData[0]);
 const audioRightChannelData = essentia.arrayToVector(audio.channelData[1]);
 const audioDownMixed = essentia.MonoMixer(audioLeftChannelData, audioRightChannelData).audio;
 
-
+// Danceability expects the whole audio file as input
 let danceability = essentia.Danceability(
     audioDownMixed, // audio frame vector
     8800, // maxTau


### PR DESCRIPTION
This PR extends node.js examples of essentia.js also fixes issue #81 occur due to the wrong example code snippet.